### PR TITLE
fix: set overlayLabel on tracks added via `track add`

### DIFF
--- a/src/commands/content.ts
+++ b/src/commands/content.ts
@@ -214,6 +214,10 @@ export async function addTrack(
     trackUrl,
     type: "audio",
     duration: options.duration,
+    // `overlayLabel` mirrors the parent chapter's, same as `entry add` and the
+    // yoto.dev docs. Without it tracks play fine in the app/iOS but fail on
+    // physical players (skip-cycle through chapters). See #1.
+    overlayLabel: chapter.overlayLabel,
     icon: mediaId,
     display: mediaId ? { icon16x16: `yoto:#${mediaId}` } : undefined,
   };


### PR DESCRIPTION
`track add` (used by the chapter add + track add workflow, as opposed to `entry add`) never wrote `overlayLabel` onto the track object. Confirmed via device testing that this is the actual cause of tracks playing fine in the Yoto app/iOS but failing on physical Yoto players (observed as the device skip-cycling through chapters without playing audio).

This mirrors the parent chapter's overlayLabel, matching the pattern used by `entry add` and the documented upload flow at yoto.dev/myo/uploading-to-cards.

Complements #2, which addresses format/channels but not this field. Fixes #1.